### PR TITLE
Call spawn with node process directly

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var util = require('util');
 var path = require('path')
 var extend = require('extend');
 var decamelize = require('decamelize');
+var process = require('process');
 
 var DEFAULTS = {
   noColor: true
@@ -31,7 +32,8 @@ GulpRunner.prototype.run = function(tasks, options, cb) {
   tasks = util.isArray(tasks) ? tasks : [tasks];
 
   var gulpBin = require.resolve('gulp/bin/gulp.js')
-  var gulp = child.spawn(gulpBin, buildOpts(tasks, options), {
+  var gulpOpts = [gulpBin].concat(buildOpts(tasks, options))
+  var gulp = child.spawn(process.execPath, gulpOpts, {
     detached: true,
     cwd: __dirname
   })


### PR DESCRIPTION
In order to run this on Windows, need to call the node executable instead of the .js file.

Otherwise, we get this error:
```
internal/child_process.js:302
    throw errnoException(err, 'spawn');
    ^

Error: spawn UNKNOWN
    at exports._errnoException (util.js:1026:11)
    at ChildProcess.spawn (internal/child_process.js:302:11)
    at Object.exports.spawn (child_process.js:380:9)
    at GulpRunner.run (<path>\node_modules\gulp-runner\index.js:34:20)
    ...
```

This addresses #2 