### PR TITLE
fix: kill spawned task on signal interruption

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,6 +52,11 @@ GulpRunner.prototype.run = function(tasks, options, cb) {
       cb(null)
     }
   });
+
+  process.on('SIGINT', function() {
+    gulp.kill();
+    process.exit(1);
+  });
 };
 
 function reemit(event) {


### PR DESCRIPTION
From my testing, it looks like the spawned instance of gulp is not killed on `sigint`. This is normally fine for quick running tasks, but for tasks that are left open (e.g. starting a server) this means that the server will stay open indefinitely.

This solves that issue! Let me know if I provide any further detail!