### PR TITLE
Experiment on running gulp w/ fork

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,14 @@ var DEFAULTS = {
   noColor: true
 }
 
-function GulpRunner(gulpfile) {
+var NODE_DEFAULTS = {
+  processType: 'spawn',
+  detached: true,
+  cwd: __dirname
+}
+
+function GulpRunner(gulpfile, opts) {
+  this.options = extend({}, NODE_DEFAULTS, opts || {})
   this.gulpfile = path.resolve(gulpfile);
 }
 
@@ -30,13 +37,9 @@ GulpRunner.prototype.run = function(tasks, options, cb) {
   options = options || (options = {})
   options.gulpfile = this.gulpfile;
   tasks = util.isArray(tasks) ? tasks : [tasks];
-
   var gulpBin = require.resolve('gulp/bin/gulp.js')
   var gulpOpts = [gulpBin].concat(buildOpts(tasks, options))
-  var gulp = child.spawn(process.execPath, gulpOpts, {
-    detached: true,
-    cwd: __dirname
-  })
+  var gulp = child[this.options.processType](process.execPath, gulpOpts, this.options)
   
   self.emit('start');
   

--- a/test/runner.js
+++ b/test/runner.js
@@ -5,6 +5,11 @@ var gulpfile = path.resolve(__dirname, 'gulpfile.js');
 var runner = new Runner(gulpfile);
 var runner1 = new Runner(gulpfile);
 var runner2 = new Runner(gulpfile);
+var runnerWithOpts = new Runner(gulpfile, {
+	processType: 'fork', 
+	detached: false,
+	silent: true
+})
 
 runner.on('start', function() {
   console.log('gulp starting...')
@@ -30,5 +35,9 @@ runner1.run('doomed', function(err) {
 })
 
 runner2.run(['default', 'task2'], function() {
+  console.log('third gulp... done')
+})
+
+runnerWithOpts.run(['default', 'task2'], function() {
   console.log('third gulp... done')
 })


### PR DESCRIPTION
This branch is an experiment with running gulp-runner w/ `child_process.fork` for debugging purposes. 

`new GulpRunner(gulpfile, [options])`

```
{
  processType: 'fork',
  detached: false,
  silent: true // Not providing this causes errors with GulpRunner reading stdout.
}
```

Even with the above opts though, I'm getting some weird errors that I don't really have time to debug right now:

```
gulp starting...
[10:33:57] Working directory changed to ~/Code/opensource/gulp-runner/test
[10:33:57] Using gulpfile ~/Code/opensource/gulp-runner/test/gulpfile.js
[10:33:57] Starting 'default'...
running some task...
Error: gulp failed
    at ChildProcess.<anonymous> (/Users/jjaques/Code/opensource/gulp-runner/index.js:52:10)
    at emitTwo (events.js:106:13)
    at ChildProcess.emit (events.js:191:7)
    at maybeClose (internal/child_process.js:852:16)
    at Socket.<anonymous> (internal/child_process.js:323:11)
    at emitOne (events.js:96:13)
    at Socket.emit (events.js:188:7)
    at Pipe._handle.close [as _onclose] (net.js:492:12)
second gulp... failed
events.js:165
      throw err;
      ^

Error: Uncaught, unspecified "error" event. (/Users/jjaques/.nvm/versions/node/v6.3.1/bin/node:1
(function (exports, require, module, __filename, __dirname) { ����
                                                              ^
SyntaxError: Unexpected token ILLEGAL
    at Object.exports.runInThisContext (vm.js:76:16)
    at Module._compile (module.js:513:28)
    at Object.Module._extensions..js (module.js:550:10)
    at Module.load (module.js:458:32)
    at tryModuleLoad (module.js:417:12)
    at Function.Module._load (module.js:409:3)
    at Module.runMain (module.js:575:10)
    at run (bootstrap_node.js:352:7)
    at startup (bootstrap_node.js:144:9)
    at bootstrap_node.js:467:3
)
    at GulpRunner.emit (events.js:163:17)
    at Socket.<anonymous> (/Users/jjaques/Code/opensource/gulp-runner/index.js:63:10)
    at emitOne (events.js:96:13)
    at Socket.emit (events.js:188:7)
    at readableAddChunk (_stream_readable.js:177:18)
    at Socket.Readable.push (_stream_readable.js:135:10)
    at Pipe.onread (net.js:542:20)
npm ERR! Test failed.  See above for more details.
```