### PR TITLE
add a "failed" event for consistency w/ "complete"

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,6 +46,7 @@ GulpRunner.prototype.run = function(tasks, options, cb) {
 
   gulp.on('close', function(code) {
     if (code !== 0) {
+      self.emit('failed', code)
       cb(new Error('gulp failed'))
     } else {
       self.emit('complete', code)


### PR DESCRIPTION
I'd like to add a simple "failed" event so that `gulp.on` listeners can be used across the board for `log`, `error`, `complete` and `failed` cases. How does that look to you?