### PR TITLE
Basic tests using Jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Programmatic API for running gulp tasks.",
   "main": "index.js",
   "scripts": {
-    "test": "node test/runner"
+    "test": "jest",
+    "test:debug": "node --debug-brk ./node_modules/.bin/jest --runInBand"
   },
   "author": "Jon Jaques <jaquers@gmail.com>",
   "license": "MIT",
@@ -16,5 +17,8 @@
     "decamelize": "^1.0.0",
     "extend": "^3.0.0",
     "gulp": "^3.9.1"
+  },
+  "devDependencies": {
+    "jest": "^19.0.2"
   }
 }

--- a/test/basic/basic.test.js
+++ b/test/basic/basic.test.js
@@ -1,0 +1,65 @@
+const path = require('path');
+const GulpRunner = require('../../index');
+const gulpfile = path.resolve(__dirname, 'gulpfile.js');
+
+
+function enableLogging(gulp) {
+    gulp.on('log', (log) => {
+        console.log(log.toString());
+    });
+    gulp.on('error', (log) => {
+        console.error(log.toString());
+    });
+}
+
+
+test('receive start event', (done) => {
+    const gulp = new GulpRunner(gulpfile);
+    gulp.on('start', () => {
+        done();
+    })
+    gulp.run('default');
+});
+
+test('receive complete event', (done) => {
+    const gulp = new GulpRunner(gulpfile);
+    gulp.on('complete', () => {
+        done();
+    })
+    gulp.run('default');
+});
+
+test('receive log event', (done) => {
+    const gulp = new GulpRunner(gulpfile);
+
+    gulp.on('log', (log) => {
+        if (log.toString().indexOf("Starting 'default'...") !== -1) {
+            done();
+        }
+    })
+    gulp.run('default');
+});
+
+test('receive error event', (done) => {
+    const gulp = new GulpRunner(gulpfile);
+
+    gulp.on('error', (log) => {
+        if (log.toString().indexOf('this is an error') !== -1) {
+            done();
+        }
+    });
+
+    gulp.run('fails');
+});
+
+test('receive failure callback', (done) => {
+    const gulp = new GulpRunner(gulpfile);
+
+    gulp.on('error', function() {});
+    
+    gulp.run('fails', function(err) {
+        expect(err).toBeInstanceOf(Error);
+        expect(err.message).toBe('gulp failed');
+        done();
+    });
+})

--- a/test/basic/gulpfile.js
+++ b/test/basic/gulpfile.js
@@ -1,0 +1,12 @@
+var gulp = require('gulp');
+
+gulp.task('default', function(done) {
+  setTimeout(function() {
+    done();
+  }, 10);
+});
+
+gulp.task('fails', function(done) {
+  console.error('this is an error');
+  throw new Error('failcake');
+});


### PR DESCRIPTION
These are a handful of basic tests I wrote against `GulpRunner` using Jest. I figure we could expand upon these to support the "failed" event in #6 and the `child_process.fork` PR that's a work in progress currently.

If you prefer these tests are written in pure ES5 syntax, let me know and I can switch them over.