### PR TITLE
Added options.gulpBin

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ GulpRunner.prototype.run = function(tasks, options, cb) {
   options.gulpfile = this.gulpfile;
   tasks = util.isArray(tasks) ? tasks : [tasks];
 
-  var gulpBin = require.resolve('gulp/bin/gulp.js')
+  var gulpBin = options.gulpBin || require.resolve('gulp/bin/gulp.js')
   var gulpOpts = [gulpBin].concat(buildOpts(tasks, options))
   var gulp = child.spawn(process.execPath, gulpOpts, {
     detached: true,

--- a/readme.md
+++ b/readme.md
@@ -23,6 +23,7 @@ gulp.run('task', function(err) {
 ```
 /* optional cli arguments (camelcased) */
 var opts = {
+  gulpBin: 'path/to/proper/gulp.js', // use when multiple versions of gulp-cli is installed in subprojects
   require: ['coffeescript', 'some-lib'],
   tasksSimple: true,
   production: true   // also accepts arbitrary flags 


### PR DESCRIPTION
In my project I have multiple subprojects with different versions of gulp.

require.resolve finds incorect file and error like bellow occurs.

```
.../gulp/bin/gulp.js:129
gulpInst.start.apply(gulpInst, toRun);
^

TypeError: Cannot read property 'apply' of undefined
```

pointing proper gulp.js file resolves problem.